### PR TITLE
support !d and !redis as well as !deris

### DIFF
--- a/go-lingrimagebot/main.go
+++ b/go-lingrimagebot/main.go
@@ -24,7 +24,7 @@ import (
 var reToken = regexp.MustCompile(`^!!(image|image_p)\s((?:.|\n)*)`)
 var reKomei = regexp.MustCompile(`^!(komei)\s((?:.|\n)*)`)
 var reYuno = regexp.MustCompile(`^!(yuno)\s((?:.|\n)*)`)
-var reDeris = regexp.MustCompile(`^!(deris)\s((?:.|\n)*)`)
+var reDeris = regexp.MustCompile(`^!(d(?:eris)?|redis)\s((?:.|\n)*)`)
 var reGolgo = regexp.MustCompile(`^!(golgo)\s((?:.|\n)*)`)
 
 type Status struct {


### PR DESCRIPTION
```
ujihisa
!osusume deris-meigen  01/28 14:34

おすすめbot
Name: deris-meigen
Regexp: /^(!d(eris)?|!redis)\s.*/
Content: $bot("imagebot")
Full definition:
!osusume deris-meigen ^(!d(eris)?|!redis)\s.* $bot("imagebot")  01/28 14:34
```

というわけで!dや!redisでも!derisできるよう対応してみました。

手元でgo buildやgo testとかのテストができなかったので動作確認していないので要注意です。
